### PR TITLE
Fix contenttype icons by normalizing class.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix contenttype icons by normalizing class.
+  [jone]
 
 
 1.1.1 (2014-05-01)

--- a/ftw/statusmap/browser/statusmap.pt
+++ b/ftw/statusmap/browser/statusmap.pt
@@ -26,7 +26,8 @@
 <body>
 <metal:main fill-slot="main">
 
-    <div metal:define-macro="main">
+    <div metal:define-macro="main"
+         tal:define="normalizeString nocall:context/@@plone/normalizeString">
 
         <h1 class="documentFirstHeading"
             i18n:translate="label_workflow_map">Workflow Map</h1>
@@ -76,7 +77,7 @@
                                         level               node/level;
                                         item_title          node/title;
                                         item_url            item/getURL|item/absolute_url;
-                                        item_type           node/type;
+                                        item_type           python: normalizeString(node['type']);
                                         item_type_class     python: 'contenttype-' + item_type;
                                         item_icon           node/icon;
                                         item_wf_state       node/review_state;


### PR DESCRIPTION
The type in the "contenttype-*" class needs to be normalized in order to work properly as everywhere else in Plone.

This is especially important for dexterity types which often contain dots in the type name.