### PR TITLE
fix portal type title when deviates from FTI id

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Fix portal type title when deviates from FTI id.
+  [jone]
+
 - Fix contenttype icons by normalizing class.
   [jone]
 

--- a/ftw/statusmap/browser/statusmap.pt
+++ b/ftw/statusmap/browser/statusmap.pt
@@ -77,8 +77,8 @@
                                         level               node/level;
                                         item_title          node/title;
                                         item_url            item/getURL|item/absolute_url;
-                                        item_type           python: normalizeString(node['type']);
-                                        item_type_class     python: 'contenttype-' + item_type;
+                                        item_type           python: node['type'];
+                                        item_type_class     python: 'contenttype-' + normalizeString(item_type);
                                         item_icon           node/icon;
                                         item_wf_state       node/review_state;
                                         item_wf_state_class python:'state-' + item_wf_state;"
@@ -110,7 +110,7 @@
                                     </a>
                                 </span>
                             </td>
-                            <td tal:content="python: view.get_translated_type(item_type)" style="white-space:nowrap;"></td>
+                            <td tal:content="python: view.get_translated_type(node['type'])" style="white-space:nowrap;"></td>
                             <td tal:content="item_wf_state"
                                         i18n:translate=""
                                         i18n:domain="plone"

--- a/ftw/statusmap/browser/statusmap.py
+++ b/ftw/statusmap/browser/statusmap.py
@@ -75,10 +75,13 @@ class StatusMap(BrowserView):
     def get_translated_type(self, portal_type):
         portal_types = getToolByName(self.context, 'portal_types')
         fti = portal_types.get(portal_type, None)
-        if fti is None or not fti.i18n_domain:
-            domain = 'plone'
-        else:
-            domain = fti.i18n_domain
+        if fti is None:
+            return translate(msgid=portal_type, domain='plone',
+                             context=self.request)
 
-        return translate(msgid=portal_type, domain=domain,
+        if not fti.i18n_domain:
+            return translate(msgid=fti.title, domain='plone',
+                             context=self.request)
+
+        return translate(msgid=fti.title, domain=fti.i18n_domain,
                          context=self.request)

--- a/ftw/statusmap/tests/test_view.py
+++ b/ftw/statusmap/tests/test_view.py
@@ -46,7 +46,7 @@ class TestStatusmapView(TestCase):
         view = self.portal.restrictedTraverse('statusmap')
         msg = view.get_translated_type('Document')
 
-        self.assertEquals(msg, u'Document')
+        self.assertEquals(msg, u'Page')
 
     def test_get_translated_type_fallback(self):
         view = self.portal.restrictedTraverse('statusmap')


### PR DESCRIPTION
The portal_type metadata in the catalog contains a string of the ID of the type's FTI.
The ID may be different from the title and the title is usually translated.

For properly translating the type, we now use the FTI title with and the FTI i18n_domain with fallbacks for when the FTI is not found or has no i18n_domain.

Example:
The ContentPage type in ftw.simplelayout has the ID `ftw.simplelayout.ContentPage` (catalog metdata `portal_type`) but the translation is in `ftw.simplelayout` domain with the message ID `ContentPage`:
- https://github.com/4teamwork/ftw.simplelayout/blob/master/ftw/simplelayout/profiles/default/types/ftw.simplelayout.ContentPage.xml#L8
- https://github.com/4teamwork/ftw.simplelayout/blob/master/ftw/simplelayout/locales/de/LC_MESSAGES/ftw.simplelayout.po#L20

// @maethu 