### PR TITLE
Add old and new state to the transitions-listing

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,9 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
+- Add old and new state to the transitions-listing
+  [elioschmutz]
+
 - Fix status message type.
   [mbaechtold]
 

--- a/ftw/statusmap/browser/statusmap.pt
+++ b/ftw/statusmap/browser/statusmap.pt
@@ -42,8 +42,8 @@
                 <legend i18n:translate="label_transition">Transition</legend>
                         <tal:repeat_transition
                                 repeat="transition transitions">
-                            <div tal:define="name python:transition[0];
-                                             title python:transition[1]"
+                            <div tal:define="name python:transition.get('id');
+                                             title python:view.get_transition_title(transition)"
                                     tal:attributes="class string:transition-${name}-colorized;">
                                 <input type="radio"
                                         onclick="statusmap.selectTransition(this);"
@@ -51,8 +51,7 @@
                                                         id name;
                                                         name string:transition;
                                                         "/>
-                                <label for="" tal:attributes="for name" i18n:translate="" i18n:domain="plone"
-                                        tal:content="python:title" />
+                                <label class="transitionLabel" tal:attributes="for name" tal:content="python:title" />
                             </div>
                         </tal:repeat_transition>
                         <br />

--- a/ftw/statusmap/browser/statusmap.py
+++ b/ftw/statusmap/browser/statusmap.py
@@ -65,12 +65,24 @@ class StatusMap(BrowserView):
     def get_json(self):
         result = {}
         for item in self.infos:
-            result[item['uid']] = [transition[0]
+            result[item['uid']] = [transition.get('id')
                                    for transition in item['transitions']]
         return json.dumps(result)
 
     def get_allowed_transitions(self):
         return "var possible_transitions = %s;" % self.get_json()
+
+    def get_transition_title(self, transition):
+        def _translate(request, msgid):
+            return translate(
+                msgid=msgid,
+                domain="plone",
+                context=request).encode('utf-8')
+
+        return '{0} - {1} => {2}'.format(
+            _translate(self.request, transition.get('id')),
+            _translate(self.request, transition.get('old_review_state')),
+            _translate(self.request, transition.get('new_review_state')))
 
     def get_translated_type(self, portal_type):
         portal_types = getToolByName(self.context, 'portal_types')

--- a/ftw/statusmap/testing.py
+++ b/ftw/statusmap/testing.py
@@ -1,15 +1,18 @@
-from plone.app.testing import IntegrationTesting
+from ftw.builder.testing import BUILDER_LAYER
+from ftw.builder.testing import functional_session_factory
+from ftw.builder.testing import set_builder_session_factory
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
 from zope.configuration import xmlconfig
 
 
 class FtwStatusmapLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, )
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         # Load ZCML
@@ -33,4 +36,7 @@ FTW_STATUSMAP_FIXTURE = FtwStatusmapLayer()
 FTW_STATUSMAP_INTEGRATION_TESTING = IntegrationTesting(
     bases=(FTW_STATUSMAP_FIXTURE, ), name="FtwStatusmap:Integration")
 FTW_STATUSMAP_FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(FTW_STATUSMAP_FIXTURE, ), name="FtwStatusmap:Functional")
+    bases=(
+        FTW_STATUSMAP_FIXTURE,
+        set_builder_session_factory(functional_session_factory)),
+    name="FtwStatusmap:Functional")

--- a/ftw/statusmap/tests/test_statusmap_integration.py
+++ b/ftw/statusmap/tests/test_statusmap_integration.py
@@ -26,9 +26,16 @@ class TestStatusmap(TestCase):
         result = getInfos(self.portal, self.cat, self.wf_tool)
 
         for item in result:
-            self.assertEqual(item['transitions'],
-                             [['publish', 'Publish'],
-                              ['submit', 'Submit for publication']])
+            self.assertEqual(
+                item['transitions'],
+                [{'new_review_state': 'published',
+                  'old_review_state': 'private',
+                  'id': 'publish',
+                  'title': 'Publish'},
+                 {'new_review_state': 'pending',
+                  'old_review_state': 'private',
+                  'id': 'submit',
+                  'title': 'Submit for publication'}])
             self.assertEqual(item['review_state'], 'private')
 
     def test_getInfos_order(self):

--- a/ftw/statusmap/tests/test_view.py
+++ b/ftw/statusmap/tests/test_view.py
@@ -37,10 +37,17 @@ class TestStatusmapView(TestCase):
             possible_trans[view.infos[2]['uid']], ['publish', 'submit'])
 
         all_trans = view.list_transitions()
+
         self.assertEqual(
             all_trans,
-            [['publish', 'Publish'],
-            ['submit', 'Submit for publication']])
+            [{'new_review_state': 'published',
+              'old_review_state': 'private',
+              'id': 'publish',
+              'title': 'Publish'},
+             {'new_review_state': 'pending',
+              'old_review_state': 'private',
+              'id': 'submit',
+              'title': 'Submit for publication'}])
 
     def test_get_translated_type(self):
         view = self.portal.restrictedTraverse('statusmap')

--- a/ftw/statusmap/utils.py
+++ b/ftw/statusmap/utils.py
@@ -8,7 +8,12 @@ def getTransitionsForItem(wf_tool, brains, dicts):
         avail_actions = []
         for action in actions:
             if action['category'] == 'workflow':
-                avail_actions.append([action['id'], action['title']])
+                avail_actions.append({
+                    'id': action['id'],
+                    'title': action['title'],
+                    'old_review_state': brain.review_state,
+                    'new_review_state': action.get('transition').new_state_id,
+                    })
         dicts[index]['transitions'] = avail_actions
     return dicts
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ tests_require = [
     'plone.testing',
     'transaction',
     'zope.configuration',
+    'ftw.builder',
+    'ftw.testbrowser',
+    'ftw.testing',
+    'plone.api',
     ]
 
 


### PR DESCRIPTION
@maethu 

Update the transition listing. Ut displays now in addition to the transition name the old and new review_state, too.

Why I did it? Sometimes we have several transitions with the same translated name, but the start and end review state are different. To be able to separate them, I added the start and end state of the transition. See printscreens below:


Old:

![bildschirmfoto 2015-09-22 um 09 41 00](https://cloud.githubusercontent.com/assets/557005/10020230/12148470-6142-11e5-9ba9-44b4d2c3a2de.png)

New:

![bildschirmfoto 2015-09-22 um 15 03 12](https://cloud.githubusercontent.com/assets/557005/10020347/aeadd296-6142-11e5-922d-f04ea44b47c9.png)
