### PR TITLE
Add StatusMapFolderTree adapter

### DIFF
--- a/ftw/statusmap/configure.zcml
+++ b/ftw/statusmap/configure.zcml
@@ -22,4 +22,8 @@
     <!-- Register translations-->
     <i18n:registerTranslations directory="locales"/>
 
+    <adapter
+      for="*"
+      factory="ftw.statusmap.utils.StatusMapFolderTree"
+      provides="ftw.statusmap.interfaces.IStatusMapFolderTree" />
 </configure>

--- a/ftw/statusmap/interfaces.py
+++ b/ftw/statusmap/interfaces.py
@@ -1,0 +1,22 @@
+from zope.interface import Interface
+
+
+class IStatusMapFolderTree(Interface):
+    """ Generates a statusmap tree based on the context.
+
+    It returns a dict with items and its nodes:
+
+    [{
+        'url': '/foo'
+        'nodes': [{
+            'url': '/foo/bar'
+            }]
+        },
+        'url': '/dummy'
+    }]
+
+    - The root object is the given context
+    - The sorting is given trough the navtree-properties
+    - The depth is unlimited
+
+    """

--- a/ftw/statusmap/tests/test_utils_statusmapfoldertree.py
+++ b/ftw/statusmap/tests/test_utils_statusmapfoldertree.py
@@ -1,0 +1,130 @@
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.statusmap.interfaces import IStatusMapFolderTree
+from ftw.statusmap.testing import FTW_STATUSMAP_FUNCTIONAL_TESTING
+from unittest2 import TestCase
+from plone import api
+
+
+class TestStatusMapFolderTree(TestCase):
+
+    layer = FTW_STATUSMAP_FUNCTIONAL_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+
+    def test_tree_on_empty_folder(self):
+        folder = create(Builder('folder'))
+        tree = IStatusMapFolderTree(folder)()
+
+        self.assertEqual(
+            1, len(tree),
+            "There should be only one root element")
+
+        self.assertEqual(
+            folder.absolute_url(), tree[0].get('url'),
+            "The root element should be the 'folder' at {0}".format(
+                folder.absolute_url()))
+
+    def test_tree_with_child_elements(self):
+        folder = create(Builder('folder'))
+
+        child1 = create(Builder('folder').within(folder))
+        child1_child = create(Builder('folder').within(child1))
+
+        child2 = create(Builder('folder').within(folder))
+
+        tree = IStatusMapFolderTree(folder)()
+
+        self.assertEqual(
+            1, len(tree),
+            "There should be only one root element")
+
+        children = tree[0].get('nodes')
+
+        self.assertEqual(
+            2, len(children),
+            "There should be two child nodes at: {0}, {1}".format(
+                child1.absolute_url(), child2.absolute_url()))
+
+        children_of_child_1 = children[0].get('nodes')
+
+        self.assertEqual(
+            1, len(children_of_child_1),
+            "The child 1 should have one child nodes at {0}".format(
+                child1_child.absolute_url()))
+
+        children_of_child_2 = children[1].get('nodes')
+
+        self.assertEqual(
+            0, len(children_of_child_2),
+            "The child 2 should have no child nodes")
+
+    def test_sorting_throught_navtree_properties(self):
+        folder = create(Builder('folder'))
+
+        create(Builder('folder')
+               .within(folder)
+               .titled("Chuck"))
+
+        bond = create(Builder('folder')
+                      .within(folder)
+                      .titled("Bond"))
+
+        create(Builder('folder')
+               .within(bond)
+               .titled("Weapons"))
+
+        create(Builder('folder')
+               .within(bond)
+               .titled("Gadgets"))
+
+        p_tool = api.portal.get_tool('portal_properties')
+        navtree_properties = getattr(p_tool, 'navtree_properties')
+
+        setattr(navtree_properties, 'sortAttribute', 'sortable_title')
+
+        tree = IStatusMapFolderTree(folder)()
+
+        # 1st Level
+        level1 = tree[0].get('nodes')
+        self.assertEqual(
+            ['Bond', 'Chuck'], [node.get('title') for node in level1],
+            'The Element should be sorted by title')
+
+        # 2nd Level
+        level2 = tree[0].get('nodes')[0].get('nodes')
+        self.assertEqual(
+            ['Gadgets', 'Weapons'], [node.get('title') for node in level2],
+            'The Element should be sorted by title')
+
+    def test_empty_review_state_if_no_wf_is_defined(self):
+        wf_tool = api.portal.get_tool('portal_workflow')
+        wf_tool.setDefaultChain('')
+
+        folder = create(Builder('folder'))
+
+        tree = IStatusMapFolderTree(folder)()
+
+        self.assertEqual(
+            '', tree[0].get('review_state'),
+            "The reviewstate should be an empty string if "
+            "no worfklow is defined"
+            )
+
+    def test_show_possible_transitions_if_wf_is_defined(self):
+            wf_tool = api.portal.get_tool('portal_workflow')
+            wf_tool.setDefaultChain('simple_publication_workflow')
+
+            folder = create(Builder('folder'))
+
+            tree = IStatusMapFolderTree(folder)()
+            self.assertEqual(
+                'private', tree[0].get('review_state'),
+                "The initialstate should be 'private'")
+
+            self.assertEqual(
+                ['publish', 'submit'],
+                [action.get('id') for action in tree[0].get('transitions')],
+                "Only possible actions from the initialstate should be listed"
+                )

--- a/ftw/statusmap/utils.py
+++ b/ftw/statusmap/utils.py
@@ -1,4 +1,7 @@
+from plone import api
 from plone.app.uuid.utils import uuidToObject
+from Products.CMFPlone.browser.navigation import get_view_url
+import os.path
 
 
 def getTransitionsForItem(wf_tool, brains, dicts):
@@ -48,3 +51,120 @@ def getInfos(context, cat, wf_tool):
     items = getBaseInfo(path, brains)
     items = getTransitionsForItem(wf_tool, brains, items)
     return items
+
+
+class StatusMapFolderTree(object):
+
+    def __init__(self, context):
+        self.context = context
+        self.wf_tool = api.portal.get_tool('portal_workflow')
+        self.catalog = api.portal.get_tool('portal_catalog')
+        self.portal_properties = api.portal.get_tool('portal_properties')
+
+    def __call__(self):
+        return self.generate_tree()
+
+    def generate_tree(self):
+        """Generates a nested tree.
+        - The root of the tree will be the context
+        - The sorting is the plonenavigation sorting
+
+        [{
+        'url': '/foo'
+        'nodes': [{
+            'url': '/foo/bar'
+            }]
+        },
+        'url': '/dummy'
+        }]
+        """
+        nodes = map(self._node, self._brains())
+        return self._make_tree_by_url(nodes)
+
+    def _node(self, brain):
+        """Converts a brain into a statusmap node
+        """
+        return dict(
+            url=get_view_url(brain)[1],
+            review_state=brain.review_state or '',
+            type=brain.portal_type,
+            icon=brain.getIcon,
+            title=brain.pretty_title_or_id(),
+            uid=brain.UID,
+            transitions=self._get_transitions_of_brain(brain),
+        )
+
+    def _action_item(self, action):
+        """Converts a workflow action object into
+        an item
+        """
+        return dict(
+            id=action['id'],
+            title=action['title'],
+            new_review_state=action.get('transition').new_state_id,
+        )
+
+    def _get_transitions_of_brain(self, brain):
+        """Returns a dict of all possible workflowactions of the brains
+        object
+
+        TODO: This function makes it slow. We need the object.
+        Perhaps we shouldn't render the whole tree?
+        """
+        obj = brain.getObject()
+        actions = self.wf_tool.listActionInfos(object=obj)
+        actions = filter(lambda x: x['category'] == 'workflow', actions)
+        return map(self._action_item, actions)
+
+    def _make_tree_by_url(self, nodes):
+        """Creates a nested tree of nodes from a flat list-like object of nodes.
+        Each node is expected to be a dict with a url-like string stored
+        under the key ``url``.
+        Each node will end up with a ``nodes`` key, containing a list
+        of children nodes.
+        The nodes are changed in place, be sure to make copies first when
+        necessary.
+        """
+
+        for node in nodes:
+            node['nodes'] = []
+
+        nodes_by_url = dict((node['url'], node) for node in nodes)
+        root = []
+
+        for node in nodes:
+            parent_url = os.path.dirname(node['url'])
+            if parent_url in nodes_by_url:
+                nodes_by_url[parent_url]['nodes'].append(node)
+            else:
+                root.append(node)
+
+        return root
+
+    def _brains(self):
+        return self.catalog.searchResults(self._query())
+
+    def _query(self):
+        query = {}
+
+        self._extend_query_with_path(query)
+        self._extend_query_with_sorting(query)
+
+        return query
+
+    def _extend_query_with_path(self, query):
+        query['path'] = '/'.join(self.context.getPhysicalPath())
+
+    def _extend_query_with_sorting(self, query):
+        navtree_properties = getattr(
+            self.portal_properties, 'navtree_properties')
+
+        sort_attribute = navtree_properties.getProperty('sortAttribute', None)
+        if sort_attribute is None:
+            return
+
+        query['sort_on'] = sort_attribute
+        sort_order = navtree_properties.getProperty('sortOrder', None)
+
+        if sort_order is not None:
+            query['sort_order'] = sort_order

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ tests_require = [
     'ftw.builder',
     'ftw.testbrowser',
     'ftw.testing',
-    'plone.api',
     ]
 
 
@@ -60,6 +59,7 @@ setup(name='ftw.statusmap',
           'Zope2',
           'zope.i18nmessageid',
           'zope.publisher',
+          'plone.api',
           # -*- Extra requirements: -*-
       ],
 


### PR DESCRIPTION
Partial PR => merge into es-638-improve-sort-order

Add `StatusMapFolderTree` adapter. 

- I'll use this adapter in a further PR for the map-render implementation.
- With this adapter, it will be possible to cleanup a lot of old code in the utils.py and statusmap.py
- This adapter can be overridden. Therefore it's possible to add a custom implementation for certain custom projects

@maethu @jone 