### PR TITLE
Fix display of transitions and states.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Display the human readable title of the transitions and states instead
+  of their id (this is useful if you have ftw.upgrade >= 1.6.2 installed).
+  [mbaechtold]
 
 
 1.2.0 (2015-09-30)

--- a/ftw/statusmap/browser/statusmap.pt
+++ b/ftw/statusmap/browser/statusmap.pt
@@ -111,9 +111,7 @@
                             </td>
                             <td tal:content="python: view.get_translated_type(node['type'])" style="white-space:nowrap;"></td>
                             <td tal:content="item_wf_state"
-                                        i18n:translate=""
-                                        i18n:domain="plone"
-                                        tal:attributes="class item_wf_state_class"></td>
+                                tal:attributes="class item_wf_state_class"></td>
                         </tr>
                     </tal:block>
                 </tbody>

--- a/ftw/statusmap/browser/statusmap.py
+++ b/ftw/statusmap/browser/statusmap.py
@@ -75,12 +75,12 @@ class StatusMap(BrowserView):
     def get_transition_title(self, transition):
         def _translate(request, msgid):
             return translate(
-                msgid=msgid,
+                msgid=msgid.decode('utf-8'),
                 domain="plone",
                 context=request).encode('utf-8')
 
-        return '{0} - {1} => {2}'.format(
-            _translate(self.request, transition.get('id')),
+        return '{0} ({1} => {2})'.format(
+            _translate(self.request, transition.get('title')),
             _translate(self.request, transition.get('old_review_state')),
             _translate(self.request, transition.get('new_review_state')))
 

--- a/ftw/statusmap/tests/test_statusmap_integration.py
+++ b/ftw/statusmap/tests/test_statusmap_integration.py
@@ -28,15 +28,15 @@ class TestStatusmap(TestCase):
         for item in result:
             self.assertEqual(
                 item['transitions'],
-                [{'new_review_state': 'published',
-                  'old_review_state': 'private',
+                [{'new_review_state': 'Published',
+                  'old_review_state': 'Private',
                   'id': 'publish',
                   'title': 'Publish'},
-                 {'new_review_state': 'pending',
-                  'old_review_state': 'private',
+                 {'new_review_state': 'Pending review',
+                  'old_review_state': 'Private',
                   'id': 'submit',
                   'title': 'Submit for publication'}])
-            self.assertEqual(item['review_state'], 'private')
+            self.assertEqual(item['review_state'], 'Private')
 
     def test_getInfos_order(self):
         result = getInfos(self.portal, self.cat, self.wf_tool)

--- a/ftw/statusmap/tests/test_view.py
+++ b/ftw/statusmap/tests/test_view.py
@@ -40,12 +40,12 @@ class TestStatusmapView(TestCase):
 
         self.assertEqual(
             all_trans,
-            [{'new_review_state': 'published',
-              'old_review_state': 'private',
+            [{'new_review_state': 'Published',
+              'old_review_state': 'Private',
               'id': 'publish',
               'title': 'Publish'},
-             {'new_review_state': 'pending',
-              'old_review_state': 'private',
+             {'new_review_state': 'Pending review',
+              'old_review_state': 'Private',
               'id': 'submit',
               'title': 'Submit for publication'}])
 

--- a/ftw/statusmap/tests/test_view_functional.py
+++ b/ftw/statusmap/tests/test_view_functional.py
@@ -48,11 +48,11 @@ class TestStatusmapViewFunctional(TestCase):
             browser.contents)
         self.assertIn(
             '<label class="transitionLabel" for="publish">'
-            'publish - private =&gt; published</label>',
+            'Publish (Private =&gt; Published)</label>',
             browser.contents)
         self.assertIn(
             '<label class="transitionLabel" for="submit">'
-            'submit - private =&gt; pending</label>',
+            'Submit for publication (Private =&gt; Pending review)</label>',
             browser.contents)
 
         browser.post(
@@ -107,9 +107,9 @@ class TestStatusmapViewFunctional(TestCase):
             "So there should be two labels. One for each transition")
 
         self.assertIn(
-            u'ver\xf6ffentlichen - privat => ver\xf6ffentlicht',
+            u'Ver\xf6ffentlichen (Privat => Ver\xf6ffentlicht)',
             [label.text for label in labels])
 
         self.assertIn(
-            u'einreichen - privat => wartend',
+            u'Zur Ver\xf6ffentlichung einreichen (Privat => Zur Redaktion eingereicht)',
             [label.text for label in labels])

--- a/ftw/statusmap/utils.py
+++ b/ftw/statusmap/utils.py
@@ -5,15 +5,31 @@ def getTransitionsForItem(wf_tool, brains, dicts):
     for index, brain in enumerate(brains):
         obj = brain.getObject()
         actions = wf_tool.listActionInfos(object=obj)
+        old_review_state_title = ''
         avail_actions = []
         for action in actions:
             if action['category'] == 'workflow':
-                avail_actions.append({
-                    'id': action['id'],
-                    'title': action['title'],
-                    'old_review_state': brain.review_state,
-                    'new_review_state': action.get('transition').new_state_id,
-                    })
+                transition = action.get('transition')
+
+                # Construct a dict where the key is the id of the state
+                # and its value is the human readable title of the state.
+                review_state_titles = {}
+                for state in transition.states.items():
+                    review_state_titles[state[0]] = state[1].title
+
+                old_review_state_title = review_state_titles[brain.review_state]
+
+                avail_actions.append(
+                    {
+                        'id': action['id'],
+                        'title': action['title'],
+                        'old_review_state': old_review_state_title,
+                        'new_review_state': review_state_titles[
+                            action.get('transition').new_state_id
+                        ],
+                    }
+                )
+        dicts[index]['review_state'] = old_review_state_title
         dicts[index]['transitions'] = avail_actions
     return dicts
 


### PR DESCRIPTION
This will display the human readable title of the transitions and states instead of their id.

## Before

<img width="892" alt="vorher" src="https://cloud.githubusercontent.com/assets/28220/11473734/66d4d916-9774-11e5-82b6-22f448e5e249.png">

--- 

## After

<img width="892" alt="nachher" src="https://cloud.githubusercontent.com/assets/28220/11473738/70b2ba0c-9774-11e5-84d6-37e30dfc7213.png">
