### PR TITLE
Support ftw.lawgiver status translations.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,6 +4,8 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
+- Support ftw.lawgiver status translations. [jone]
+
 - Drop Plone 4.1 support.
   [elioschmutz]
 

--- a/ftw/statusmap/browser/statusmap.pt
+++ b/ftw/statusmap/browser/statusmap.pt
@@ -111,6 +111,8 @@
                             </td>
                             <td tal:content="python: view.get_translated_type(node['type'])" style="white-space:nowrap;"></td>
                             <td tal:content="item_wf_state"
+                                i18n:translate=""
+                                i18n:domain="plone"
                                 tal:attributes="class item_wf_state_class"></td>
                         </tr>
                     </tal:block>


### PR DESCRIPTION
ftw.lawgiver has changed the status message IDs in 1.6.1 in order to fix issues with Plone translations.
The status must be translated in the Plone domain now.

See https://github.com/4teamwork/ftw.lawgiver/pull/60