### PR TITLE
Fix statusmap view when being called on an inactive content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix statusmap view when being called on an inactive content. [mbaechtold]
 
 
 1.4.0 (2016-12-29)

--- a/ftw/statusmap/utils.py
+++ b/ftw/statusmap/utils.py
@@ -67,6 +67,17 @@ def executeTransition(context, wf_tool, transition, uids, comment):
 def getInfos(context, cat, wf_tool):
     path = '/'.join(context.getPhysicalPath())
     brains = cat.searchResults({'path': path, 'sort_on': 'path'})
+
+    # If the context is inactive (expired or in the future) we need to
+    # prepend the brain of the context. Otherwise it won't be listed in
+    # the status map and depending on certain publisher constraints will
+    # lead to a confusing error message.
+    if brains and brains[0].getObject() != context:
+        brains = cat.searchResults(
+            path={'query': path, 'depth': 0},
+            show_inactive=True,
+        ) + brains
+
     items = getBaseInfo(path, brains)
     items = getTransitionsForItem(wf_tool, brains, items)
     return items


### PR DESCRIPTION
If the context is inactive (expired or in the future) and the user does not have the permissions to access future or expired content, the context was not included in the statusmap which was leading to a confusing error message in combination with certain publisher constraints.

This is solved by adding the context to the list of objects if it is not there yet.